### PR TITLE
fait de int_to_char une fonction nichée

### DIFF
--- a/modules/corrections/exo_spreadsheet.py
+++ b/modules/corrections/exo_spreadsheet.py
@@ -2,26 +2,25 @@ from nbautoeval.exercise_function import ExerciseFunction
 from nbautoeval.args import Args
 
 # @BEG@ name=spreadsheet
-def int_to_char(n):
-    """
-    traduit un entier entre 1 et 26 
-    en un caractère entre 'A' et 'Z'
-    """
-    # si index était compris entre 0 et 25, on pourrait obtenir
-    # la lettre comme étant chr(ord('A') + index)
-    # on fait donc un changement de variable n -> n-1
-    # de plus on va rendre le résultat cyclique modulo 26
-    # pour pouvoir l'utiliser sur des nombres quelconques
-
-    return chr(ord('A') + (n - 1) % 26)
-
-
 def spreadsheet(index):
     """
     transforme un numéro de colonne en nom alphabétique
     dans l'ordre lexicographique
     1 -> A; 26 -> Z; 27 -> AA; 28 -> AB; etc..
     """
+    def int_to_char(n):
+        """
+        traduit un entier entre 1 et 26 
+        en un caractère entre 'A' et 'Z'
+        """
+        # si index était compris entre 0 et 25, on pourrait obtenir
+        # la lettre comme étant chr(ord('A') + index)
+        # on fait donc un changement de variable n -> n-1
+        # de plus on va rendre le résultat cyclique modulo 26
+        # pour pouvoir l'utiliser sur des nombres quelconques
+
+        return chr(ord('A') + (n - 1) % 26)
+
     # index peut être supérieur à 26
     # en remarquant que la dernière lettre s'incrémente à chaque fois 
     # qu'index augmente, et repasse à 'A' de manière cyclique, 


### PR DESCRIPTION
La fonction int_to_char n'a pas besoin d'être exposée dans
l'espace de nommage global.
L'inclure dans spreadsheet permet également de montrer
un cas concret où il est pratique de définir une fonction
à l'intérieur d'une autre fonction.